### PR TITLE
Update ReportDecoder.java

### DIFF
--- a/gbt32960-codec/src/main/java/com/ime/gbt32960/codec/ReportDecoder.java
+++ b/gbt32960-codec/src/main/java/com/ime/gbt32960/codec/ReportDecoder.java
@@ -239,7 +239,7 @@ public class ReportDecoder {
                 .setCurrent(in.readShort() / 10.0f - 1000)
                 .setBatteryTotalCount(in.readUnsignedShort())
                 .setFrameStartBatterySeq(in.readUnsignedShort());
-        int count = in.readByte();
+        int count = in.readByte() & 0xFF;//fix for count between 128-200
         for (int i = 0; i < count; i++) {
             builder.addBatteryVoltage(in.readUnsignedShort() / 1000.0f);
         }


### PR DESCRIPTION
if in.readBytes returns 0x80, int count will be -128. standard allows count values between 1~200